### PR TITLE
Add an annotate script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ envvars.sh
 # generated files when executing the workflow
 *.csv
 *.csv
+*.txt

--- a/annotate.sh
+++ b/annotate.sh
@@ -23,7 +23,7 @@ flask --app vec_search export-rad-to-csv rad-$lang-lang-$initials.csv
 # with openai
 flask --app vec_search gen-llm-rels rad-python-lang-dr.csv llm_gen_rel-openai-python-dr.csv
 
-flask --app vec_search gen-ir-metrics llm_gen_rel-openai-python-dr.csv > metrics-openai-python-dr.txt
+flask --app vec_search gen-ir-metrics llm_gen_rel-openai-$lang-$initials.csv > metrics-openai-$lang-$initials.txt
 
 # with gemini
 flask --app vec_search gen-llm-rels rad-python-lang-dr.csv llm_gen_rel-gemini-python-dr.csv gemini

--- a/annotate.sh
+++ b/annotate.sh
@@ -18,7 +18,7 @@ echo "got: $initials"
 flask --app vec_search init-db 
 flask --app vec_search run --debug
 
-flask --app vec_search export-rad-to-csv rad-python-lang-dr.csv 
+flask --app vec_search export-rad-to-csv rad-$lang-lang-$initials.csv 
 
 # with openai
 flask --app vec_search gen-llm-rels rad-python-lang-dr.csv llm_gen_rel-openai-python-dr.csv

--- a/annotate.sh
+++ b/annotate.sh
@@ -21,7 +21,7 @@ flask --app vec_search run --debug
 flask --app vec_search export-rad-to-csv rad-$lang-lang-$initials.csv 
 
 # with openai
-flask --app vec_search gen-llm-rels rad-python-lang-dr.csv llm_gen_rel-openai-python-dr.csv
+flask --app vec_search gen-llm-rels rad-$lang-lang-$initials.csv llm_gen_rel-openai-$lang-$initials.csv
 
 flask --app vec_search gen-ir-metrics llm_gen_rel-openai-$lang-$initials.csv > metrics-openai-$lang-$initials.txt
 

--- a/annotate.sh
+++ b/annotate.sh
@@ -28,4 +28,4 @@ flask --app vec_search gen-ir-metrics llm_gen_rel-openai-$lang-$initials.csv > m
 # with gemini
 flask --app vec_search gen-llm-rels rad-$lang-lang-$initials.csv llm_gen_rel-gemini-$lang-$initials.csv gemini
 
-flask --app vec_search gen-ir-metrics llm_gen_rel-gemini-python-dr.csv > metrics-gemini-python-dr.txt
+flask --app vec_search gen-ir-metrics llm_gen_rel-gemini-$lang-$initials.csv > metrics-gemini-$lang-$initials.txt

--- a/annotate.sh
+++ b/annotate.sh
@@ -26,6 +26,6 @@ flask --app vec_search gen-llm-rels rad-$lang-lang-$initials.csv llm_gen_rel-ope
 flask --app vec_search gen-ir-metrics llm_gen_rel-openai-$lang-$initials.csv > metrics-openai-$lang-$initials.txt
 
 # with gemini
-flask --app vec_search gen-llm-rels rad-python-lang-dr.csv llm_gen_rel-gemini-python-dr.csv gemini
+flask --app vec_search gen-llm-rels rad-$lang-lang-$initials.csv llm_gen_rel-gemini-$lang-$initials.csv gemini
 
 flask --app vec_search gen-ir-metrics llm_gen_rel-gemini-python-dr.csv > metrics-gemini-python-dr.txt

--- a/annotate.sh
+++ b/annotate.sh
@@ -1,4 +1,12 @@
-# replace language and userid every time annotate workflow runs
+#!/bin/bash                                                                     
+                                                                                
+echo "Enter your programming language, e.g. C, go, java, js, or python:"        
+read lang                                                                       
+echo "got: $lang"                                                               
+                                                                                
+echo "Enter your initials: "                                                    
+read initials                                                                   
+echo "got: $initials"  
 # could give them as cmd line args
 
 # openai key export  and google auth login can be included here or performed before start

--- a/annotate.sh
+++ b/annotate.sh
@@ -1,0 +1,23 @@
+# replace language and userid every time annotate workflow runs
+# could give them as cmd line args
+
+# openai key export  and google auth login can be included here or performed before start
+# modify config.db for lang first too
+
+# follow terminal to interact with app
+# initdb and create new userid/pass for each lang and each user (every time we run annotate.sh)
+
+flask --app vec_search init-db 
+flask --app vec_search run --debug
+
+flask --app vec_search export-rad-to-csv rad-python-lang-dr.csv 
+
+# with openai
+flask --app vec_search gen-llm-rels rad-python-lang-dr.csv llm_gen_rel-openai-python-dr.csv
+
+flask --app vec_search gen-ir-metrics llm_gen_rel-openai-python-dr.csv > metrics-openai-python-dr.txt
+
+# with gemini
+flask --app vec_search gen-llm-rels rad-python-lang-dr.csv llm_gen_rel-gemini-python-dr.csv gemini
+
+flask --app vec_search gen-ir-metrics llm_gen_rel-gemini-python-dr.csv > metrics-gemini-python-dr.txt


### PR DESCRIPTION
To speed up human annotation, this annotate.sh script runs once per language.

It can be streamlined further with cmd line args but this is a start.

```bash
source annotate.sh
```

Metrics written to txt files and uploaded to bucket.