### PR TITLE
add a check on envvar for an ai

### DIFF
--- a/annotate.sh
+++ b/annotate.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+if [[ -z "${OPENAI_API_KEY}" ]]; then
+  echo "The openai api key env var is not set, please set a value and reinvoke"
+  exit 1
+
 echo "Enter your programming language, e.g. C, go, java, js, or python:"
 read lang
 echo "got: $lang"

--- a/annotate.sh
+++ b/annotate.sh
@@ -3,7 +3,7 @@
 if [[ -z "${OPEN_AI_API_KEY}" ]]; then
   echo "The openai api key env var is not set, please set a value and reinvoke"
   exit 1
-
+fi
 echo "Enter your programming language, e.g. C, go, java, js, or python:"
 read lang
 echo "got: $lang"

--- a/annotate.sh
+++ b/annotate.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [[ -z "${OPENAI_API_KEY}" ]]; then
+if [[ -z "${OPEN_AI_API_KEY}" ]]; then
   echo "The openai api key env var is not set, please set a value and reinvoke"
   exit 1
 


### PR DESCRIPTION
Context: 

If I switch my IDE then the env var may get dropped and I may forget to reset the env var. The error only occurs when the AI annotations are requested and then I need to go in and manually re-execute the lines after the annotation for openai. 
Doing so also requires interpolating the `lang` and the `initials` values manually.

This change checks for the presence of a non-empty env var for openai api. If there is no env var set for openai then it will fail fast-before starting the entire workflow, and prompt the human to set the api key for openai.

Not a huge deal but hopefully this is helpful for future annotations. 