### PR TITLE
add a cmd to calculate doc coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,3 +299,13 @@ flask --app vec_search rad-merge rad1.csv rad2.csv merged.csv
 The `merged.csv` file can them be used in all downstream steps, e.g. `gen-llm-rels` and the output from the `gen-llm-rels`-using the merged file-is used as input to the `gen-ir-metrics` command.
 
 For instance, using the merged file, run (with the default AI),`flask --app vec_search gen-llm-rels merged.csv llm_gen_rel.csv`, and then, to get metrics, `flask --app vec_search gen-ir-metrics llm_gen_rel.csv`, which will output the calculated metrics to stdout as usual.
+
+# Calculate the proportion of function declarations in repositories which do and do not have docs
+
+Not all function declarations will have documentation in a given repo. To calculate the proportion we include a convenience function:
+
+```bash
+flask --app vec_search docs-cov-top-level Collections-{C,go,js,java,python}.jsonl
+```
+
+or you can list the filenames out in full.

--- a/vec_search/config.py
+++ b/vec_search/config.py
@@ -38,7 +38,7 @@ AI_MODEL = 'microsoft/codebert-base-mlm'
 # Some of these entries are used for the browser gui only
 # but might be used for other items in future, e.g. link via file:// to the
 # local location (on disk) etc.
-_JSONL_LOCAL_FILE = "Collections-python.jsonl"
+_JSONL_LOCAL_FILE = "Collections-C.jsonl"
 
 # this corresponds to the sub-directory under space that has the sqlite extension
 # development environment

--- a/vec_search/db.py
+++ b/vec_search/db.py
@@ -207,6 +207,24 @@ def rad_merge(filenames, output_filename):
     click.echo("all done ...")
 
 
+@click.command('docs-cov-top-level')
+@click.argument('filenames', nargs=-1, type=click.Path(exists=True))
+def docs_cov_top_level(filenames):
+    # for a given indexed repo determine how much indexed code has docs
+    for file in filenames:
+        no_docs_cnt, ttl_entities = 0, 0
+        print(f"Processing file: {file}")
+        with jsonlines.open(file) as reader:
+            for _, obj in enumerate(reader, start=1):
+                # NOTE: in the indexing code I use this string literal if no docs
+                if obj['docstring'] == 'NO-DOCs':
+                    no_docs_cnt +=1
+                ttl_entities += 1
+        print(f"Total Function Declarations: {ttl_entities}")
+        print(f"Total Function Declarations without docs: {no_docs_cnt}")
+        print(f"Proportion without docs: {round(100*no_docs_cnt/ttl_entities, 2)}%")
+
+
 def init_app(app):
     app.teardown_appcontext(close_db)
     app.cli.add_command(init_db_command)
@@ -215,3 +233,4 @@ def init_app(app):
     app.cli.add_command(gen_ir_metrics)
     app.cli.add_command(reset_users)
     app.cli.add_command(rad_merge)
+    app.cli.add_command(docs_cov_top_level)


### PR DESCRIPTION
The cmd reads in each indexed repo and summarized what proportion of the function declarations have documentation or the placeholder. 

I'll put the output into one of the tables. 

@D-Roberts (when you've got a chance) please take a look 