### PR TITLE
add batch support for aws bedrock

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ to see the schema for all tables in the REPL environment:
 SELECT * FROM sqlite_master WHERE type='table';
 ```
 
-# LLM annotation workflow (WIP-work in progress)
+# LLM annotation workflow
 
 A backend/batch workflow where relevances are assessed outside of a human workflow
 is the behavior currently supported. Assuming in the previous step you wrote the human generated
@@ -241,12 +241,17 @@ flask --app vec_search gen-llm-rels <input-csv> <output-csv> <llm-model-name> <d
 
 The defaults for the last 2 are `'openai'` and `'takelast'`.
 
-Also supported for `llm-model-name` are: `gemini`, more to be added.
+Also supported for `llm-model-name` are: `gemini`, and `aws`.
 
 There prompt is in the `llm_rel_gen.py` module, we use the umbrella prompt.
 
-Note: if you use the openai llm you need an api key in `OPEN_AI_API_KEY` env var, if you use the gemini model you need the `GCP_PROJECT_ID` env var
-set to a project which has the necessary privileges and you need to modify the bucket names for your project.
+Notes:
+- If you use the openai llm you need an api key in `OPEN_AI_API_KEY` environment variable.
+- If you use the gemini model you need the `GCP_PROJECT_ID` environment variable.
+  set to a project which has the necessary privileges and you need to modify the bucket names for your project.
+- If you use the `aws` command, you need:
+  `ACCESS_KEY`, `SECRET_KEY`, `AWS_REGION`, `AWS_ACCT_ID`, `BUCKET_NAME` all set to appropriate values for the
+  AWS account and organization used. Also, you'll need to create an IAM role that can be assumed with the appropriate permissions and name it `bedrock-batch-role` or rename the role in the `bedrock_batch.py` module.
 
 
 For TODOs cf. [this open issue](https://github.com/rlucas7/code-searcher/issues/10)

--- a/annotate.sh
+++ b/annotate.sh
@@ -13,8 +13,8 @@ read initials
 echo "got: $initials"
 # could give them as cmd line args
 
-# openai key export  and google auth login need to be  performed before start
-# modify config.py for lang first
+# openai key export and google auth login need to be  performed before start
+# modify `config.py` for lang first-before running this script
 
 # follow terminal to interact with app
 # initdb and for each lang and each user (every time we each run annotate.sh)
@@ -24,12 +24,9 @@ flask --app vec_search run --debug
 
 flask --app vec_search export-rad-to-csv rad-$lang-lang-$initials.csv
 
-# with openai
-flask --app vec_search gen-llm-rels rad-$lang-lang-$initials.csv llm_gen_rel-openai-$lang-$initials.csv
-
-flask --app vec_search gen-ir-metrics llm_gen_rel-openai-$lang-$initials.csv > metrics-openai-$lang-$initials.txt
-
-# with gemini
-flask --app vec_search gen-llm-rels rad-$lang-lang-$initials.csv llm_gen_rel-gemini-$lang-$initials.csv gemini
-
-flask --app vec_search gen-ir-metrics llm_gen_rel-gemini-$lang-$initials.csv > metrics-gemini-$lang-$initials.txt
+for provider in aws openai gemini;
+do
+  echo "Generating relevances for: $provider";
+  flask --app vec_search gen-llm-rels rad-$lang-lang-$initials.csv llm_gen_rel-$provider-$lang-$initials.csv
+  flask --app vec_search gen-ir-metrics llm_gen_rel-$provider-$lang-$initials.csv > metrics-$provider-$lang-$initials.txt
+done;

--- a/vec_search/bedrock_batch.py
+++ b/vec_search/bedrock_batch.py
@@ -1,0 +1,230 @@
+""" This module contains the code for the bedrock batch request workflow
+"""
+import os
+
+from enum import Enum
+from string import Template
+from typing import Optional, Any
+from time import sleep
+
+import boto3
+import uuid
+import json
+
+from pandas import DataFrame, notna, concat
+from pydantic import BaseModel, Field, ConfigDict
+
+
+# some helper codes
+def gen_record_id(index: int, prefix: str = "REC") -> str:
+    """Generate an 11 character alphanumeric record ID."""
+    return f"{prefix}{str(index).zfill(8)}"
+
+
+class ModelType(Enum):
+    TITAN_TEXT_EXPRESS = "amazon.titan-text-express-v1"
+    NOVA_LITE = "us.amazon.nova-lite-v1:0"
+
+
+class BaseGenerationConfig(BaseModel):
+    # settings matche gemini settings we use
+    temperature: float = 0.4
+    top_p: float = 0.95
+    max_tokens: int = 512
+    stop_sequences: Optional[list[str]] = Field(default_factory=list)
+    top_k: Optional[int] = 40 # gemini's default
+    system: Optional[str] = None
+    model_config = ConfigDict(
+        populate_by_name=True
+    )
+
+class NovaPrompt(BaseModel):
+    inputText: list[dict[str, Any]]
+    textGenerationConfig: dict
+
+    def model_dump(self, *args, **kwargs) -> dict:
+        # the dict formats need to follow this:
+        # https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_Converse.html
+        return {
+            "messages": self.inputText,
+            "inferenceConfig": {
+                 "maxTokens": 512,
+                 "stopSequences": [],
+                 "temperature": 0.4,
+                 "topP": 0.99,
+            },
+        }
+
+def dataframe_to_jsonl(
+    df: DataFrame,
+    model_type: ModelType,
+    output_file: str,
+    prompt: Template,
+    record_id_column: Optional[str] = None,
+    base_config: Optional[BaseGenerationConfig] = None
+) -> None:
+    """
+    Convert a DataFrame to a JSONL file for batch inference.
+
+    Args:
+        df: Input DataFrame containing text and optional configuration columns
+        model_type: Type of model to generate prompts for
+        output_file: Path to save the JSONL file
+        prompt:  The prompt containing input text
+        record_id_column: Optional column name containing record IDs
+        base_config: Default configuration to use for missing values
+    """
+    if base_config is None:
+        base_config = BaseGenerationConfig()
+
+    with open(output_file, 'w') as f:
+        for idx, row in df.iterrows():
+            # Get or generate record ID
+            record_id = str(row[record_id_column]) if record_id_column and record_id_column in row else gen_record_id(idx)
+            # Create config from row data, falling back to base_config for missing values
+            config_dict = base_config.model_dump()
+            for field in config_dict.keys():
+                if field in row and notna(row[field]):
+                    config_dict[field] = row[field]
+
+            row_config = BaseGenerationConfig(**config_dict)
+            # Create batch inference record
+            # similar logic across: concat docstring and code
+            passage = row['doc'] + "\n\n\n" + row['code']
+            tp = {'query': row['query'], 'passage': passage}
+            content = prompt.safe_substitute(tp)
+
+            body = [{"role": 'user',
+                     "content": [{'text': content}]
+                    }]
+            record = {
+                "recordId": record_id,
+                "modelInput": get_request_body(
+                    text=body,
+                    model_type=model_type,
+                    config=row_config
+                )
+            }
+            f.write(json.dumps(record) + '\n')
+
+
+def get_request_body(text: list[dict[str, Any]], model_type: ModelType, config: Optional[BaseGenerationConfig] = None) -> NovaPrompt:
+    if config is None:
+        config = BaseGenerationConfig()
+
+    if model_type == ModelType.NOVA_LITE:
+        return NovaPrompt(
+            inputText=text,
+            textGenerationConfig={
+                "temperature": config.temperature,
+                "max_tokens": config.max_tokens,
+                "stop_sequences": config.stop_sequences
+            }
+        ).model_dump()
+    raise ValueError(f"Unknown model type: {model_type}")
+
+
+def bb(df, prompt, output_filename):
+    """executes a batch request against aws bedrock service
+
+    Args:
+        df: A pandas dataframe with the relevant data from human annotations
+        prompt: A Template string with relevance annotations instruction from humans
+    """
+    config = BaseGenerationConfig(
+        temperature=0.4,
+        max_tokens=512,
+        stop_sequences=[],
+        system="You are a helpful assistant. Please use the context to answer the question that follows."
+    )
+
+    ACCESS_KEY=os.environ.get("ACCESS_KEY")
+    SECRET_KEY=os.environ.get("SECRET_KEY")
+    AWS_REGION=os.environ.get("AWS_REGION")
+    AWS_ACCT_ID = os.environ.get("AWS_ACCT_ID")
+    BUCKET_NAME = "annotate-io-batch-llm-data"
+    NOVA = "us.amazon.nova-lite-v1:0"
+    # this is iam-role, we need a role
+    # so we can delegate to the batch service
+    arn = f"arn:aws:iam::{AWS_ACCT_ID}:role/bedrock-batch-role"
+    model_id = ModelType(NOVA)
+    bucket_prefix = f"batch_requests_{model_id}-lrr.jsonl"
+    # TODO: cleanup the format for the input to the batch job here
+    dataframe_to_jsonl(
+        df=df,
+        model_type=model_id,
+        output_file='./examples.jsonl', # same filename
+        prompt=prompt,
+        base_config=config
+    )
+    print(f"Uploading to s3://{BUCKET_NAME}/{bucket_prefix}")
+    s3 = boto3.client('s3',
+        aws_access_key_id=ACCESS_KEY,
+        aws_secret_access_key=SECRET_KEY,
+        region_name=AWS_REGION
+    )
+    s3.upload_file(Filename='./examples.jsonl', Bucket=BUCKET_NAME, Key=bucket_prefix)
+    print(f"Uploading to s3 complete")
+    # added from here down
+    print("invoking bedrock for relevances")
+    inputDataConfig=({
+        "s3InputDataConfig": {
+            "s3Uri": f"s3://{BUCKET_NAME}/{bucket_prefix}"
+        }
+    })
+
+    outputDataConfig=({
+        "s3OutputDataConfig": {
+            "s3Uri": f"s3://{BUCKET_NAME}/"
+        }
+    })
+
+    bedrock = boto3.client('bedrock',
+        aws_access_key_id=ACCESS_KEY,
+        aws_secret_access_key=SECRET_KEY,
+        region_name=AWS_REGION
+    )
+    print("invoking batch job")
+    # get first part of the uuid
+    a_uuid = hex(uuid.uuid4().fields[0])[2:]
+    response = bedrock.create_model_invocation_job(
+        roleArn=arn,
+        modelId=model_id.NOVA_LITE.value,
+        jobName=f"nova-eval-{a_uuid}",
+        inputDataConfig=inputDataConfig,
+        outputDataConfig=outputDataConfig
+    )
+    print(response)
+    jobArn = response.get('jobArn')
+    poll_cnt, max_poll_cnt = 1, 20
+
+    while poll_cnt < max_poll_cnt:
+        sleep(30)
+        jobInfo = bedrock.get_model_invocation_job(jobIdentifier=jobArn)
+        if jobInfo['status'] == "Completed":
+            print(f"job: {jobArn} finished")
+            break
+        else:
+            print(f"job: {jobArn} is in state: {jobInfo['status']}")
+            poll_cnt += 1
+            print("---")
+    else:
+        print(f"max polling iteration: {max_poll_cnt} reached ...")
+
+    if jobInfo['status'] == "Completed":
+        # the jobArn characters are the same as the results folder in bucket
+        jobDir = jobArn.split('/')[-1]
+        batch_out = f"{jobDir}/{bucket_prefix}.out"
+        s3.download_file(BUCKET_NAME, batch_out, f"bedrock_batch_output_{jobDir}.jsonl")
+        print("output file downloaded")
+        # TODO: here parse the output file into the desired format...
+        data = []
+        with open(f"bedrock_batch_output_{jobDir}.jsonl", 'r') as f:
+            for line in f:
+                rd = json.loads(line)
+                data.append(rd['modelOutput']['output']['message']['content'][0]['text'])
+        # construct parsed data
+        p_df = DataFrame({'message': data})
+        c_df = concat([df, p_df], axis=1)
+        c_df['llm_rel_score'] = c_df['message'].str.split(':').apply(lambda x: max(0, min(int(x[1].strip()), 1)))
+        c_df.to_csv(output_filename)

--- a/vec_search/db.py
+++ b/vec_search/db.py
@@ -143,7 +143,7 @@ sqlite3.register_converter(
 @click.command('gen-llm-rels')
 @click.argument('filename', type=click.Path(exists=True))
 @click.argument('output_filename', type=click.Path(exists=False))
-@click.argument('llm_model', type=str, default='openai')
+@click.argument('llm_model', type=click.Choice(['openai', 'gemini', 'aws']))
 @click.argument('dupstrat', type=str, default='takelast')
 def gen_llm_rels(filename, output_filename, llm_model, dupstrat):
     ## NOTE:

--- a/vec_search/llm_rel_gen.py
+++ b/vec_search/llm_rel_gen.py
@@ -15,7 +15,6 @@ from pandas import DataFrame, concat
 
 # llm clients
 import vertexai
-import openai
 
 from openai import OpenAI
 from vertexai.batch_prediction import BatchPredictionJob
@@ -51,10 +50,6 @@ class LLMRelAssessor(LLMRelAssessorBase):
         shot_count: int = 0
     ):
         super().__init__(df=df, output_filename=output_filename, shot_count=shot_count, prompt=prompt, model_name=model_name)
-        # TODO: consider using `dotenv` package as part of app config overal refactor
-        # if not os.environ["OPEN_AI_API_KEY"]:
-        #    raise ValueError("error the OPEN_AI_API_KEY environment variable is not set")
-        # self.qrel = qrel # TODO: figure out why this is necessary in trec & umbrela codes ...
         self._create_client(model_name=model_name)
 
     def _create_client(self, model_name: str) -> None:
@@ -63,7 +58,6 @@ class LLMRelAssessor(LLMRelAssessorBase):
             api_key = os.environ["OPEN_AI_API_KEY"]
             self.client = OpenAI(api_key=api_key)
         elif model_name == "gemini":
-            # requires a project setup in google cloud-make env
             PROJECT_ID = os.environ.get("GCP_PROJECT_ID")
             LOCATION = os.environ.get("GCP_LOCATION", "us-central1")
             vertexai.init(project=PROJECT_ID, location=LOCATION)
@@ -72,6 +66,10 @@ class LLMRelAssessor(LLMRelAssessorBase):
             model = "gemini-1.5-pro-001"
             self.client = BatchPredictionJob
             self.model_name = model
+        elif model_name == "aws":
+            # NOTE: aws code is in bedrock_batch.py
+            self.model_name = "us.amazon.nova-lite-v1:0"
+            self.client = None
         else:
             raise ValueError(f"model {self.model_name} is not currently supported ...")
 
@@ -83,7 +81,7 @@ class LLMRelAssessor(LLMRelAssessorBase):
                 print(f"processing index: {index} ...")
                 # access of all entries follows via column name as key
                 query = row['query']
-                passage = row['doc'] + "\n\n\n" + row['query']
+                passage = row['doc'] + "\n\n\n" + row['code']
                 tp = {'query': query, 'passage': passage}
                 content = self.prompt.safe_substitute(tp)
                 response = self.client.chat.completions.create(
@@ -98,20 +96,18 @@ class LLMRelAssessor(LLMRelAssessorBase):
                     llm_gen_data[key].append(value)
             llm_gen_df = DataFrame(llm_gen_data)
             c_df = concat([llm_gen_df, self.df], axis=1)
-            # if the respon score is not 0/1 then convert it
+            # if the score is not 0/1 then convert/binarize it
             c_df['llm_rel_score'] = c_df['message'].str.split(':').apply(lambda x: max(0, min(int(x[1].strip()), 1)))
-            # write results to local filesystem
             c_df.to_csv(self.output_filename)
         elif self.model_name == "gemini-1.5-pro-001":
             input_bucket_name = "batch-llm-relevance-inputs"
             output_bucket_name = "gemini-completions-batch"
             storage_client = storage.Client()
-            # NOTE: annoyingly a generic 'gemini-1.5-pro' will raise an error
             # format df and write to `input_bucket`
             with open('./examples.jsonl', 'w') as f:
                 for index, row in self.df.iterrows():
                     query = row['query']
-                    passage = row['doc'] + "\n\n\n" + row['query']
+                    passage = row['doc'] + "\n\n\n" + row['code']
                     tp = {'query': query, 'passage': passage}
                     content = self.prompt.safe_substitute(tp)
                     r = {"request":
@@ -168,6 +164,10 @@ class LLMRelAssessor(LLMRelAssessorBase):
             c_df = concat([df, self.df], axis=1)
             c_df['llm_rel_score'] = df['message'].str.split(':').apply(lambda x: max(0, min(int(x[1].strip()), 1)))
             c_df.to_csv(self.output_filename)
+        elif self.model_name == "us.amazon.nova-lite-v1:0":
+            from .bedrock_batch import bb
+            print("aws bedrock batch workflow starting ...")
+            bb(df=self.df, prompt=self.prompt, output_filename=self.output_filename)
         else:
             raise NotImplementedError(f"generate_rel for client: {self.client!r} not implemented...")
 
@@ -261,78 +261,3 @@ format of:
 
 ##final score: score without providing any reasoning.
 """
-
-_llm_rel_assess = """
-You are a search quality rater evaluating the relevance
-of web pages. Given a query and a web page, you must
-provide a score on an integer scale of 0 to 2 with the
-following meanings:
-2 = highly relevant, very helpful for this query
-1 = relevant, may be partly helpful but might contain
-other irrelevant content
-0 = not relevant, should never be shown for this query
-Assume that you are writing a report on the subject of the
-topic. If you would use any of the information contained
-in the web page in such a report, mark it 1. If the web page
-is primarily about the topic, or contains vital information
-about the topic, mark it 2. Otherwise, mark it 0.
-
-Query
-A person has typed
-$query
-into a search engine.
-
-They were looking for:
-$narrative
-
-Result
-Consider the following web page.
-—BEGIN CONTENT—
-$passage
-—END CONTENT—
-Instructions
-Split this problem into steps:
-
-Measure how well the content matches a likely intent of
-the query (M).
-
-Measure how trustworthy the web page is (T).
-
-Consider the aspects above and the relative importance
-of each, and decide on a final score (O).
-
-Produce a JSON array of scores without providing any
-reasoning. Example: [{"M": 2, "T": 1, "O": 1}, {"M":
-1 . . .
-Results
-[{
-"""
-
-# Note the narrative for the second prompt is unlikely to be provided
-# given that we do not have a browser worflow interface setup for this part-yet.
-
-# TODO: make the narrative optional
-# TODO: implement the narrative input workflow
-
-
-if __name__ == "__main__":
-    ## NOTE: intended for lightweight spot checking during dev work only...
-    prompt = Prompt(_umb_promt)
-    llm_rel = LLMRelAssessor(prompt=prompt)
-    # NOTE: if you switch passage with, say 'ok?' the returned score flips 0 -> 3...
-    tp = {'query': 'Say this is a test', 'passage': 'say this is a test'}
-    resp = llm_rel.generate_rel(template_params=tp)
-    # NOTE: not sure if other llm clients have the `to_dict` on their responses...
-    rd = resp.to_dict()
-    if len(rd['choices']) > 1:
-        print("multiple choices in response, taking the first...")
-    choice = rd['choices'][0]
-    stuff = {
-        'llm_client': 'openai',
-        'msg-id': rd['id'],
-        'model-id': rd['model'],
-        'finish-reason': choice['finish_reason'],
-        'message': choice['message']['content'],
-        'usage': rd['usage']
-    }
-    print(stuff)


### PR DESCRIPTION
@D-Roberts PTAL when you've got a moment 

  * currently this supports the NOVA-lite model but other ones from the NOVA family can be added TITAN family models are not supported in batch mode by aws bedrock at the moment so they cannot be tested.

I can share the credentials for aws account via other channels.  