### PR TITLE
make the embedding llm load into memory only if app is run for browser

### DIFF
--- a/vec_search/__init__.py
+++ b/vec_search/__init__.py
@@ -1,13 +1,18 @@
 import os
-
 from flask import Flask
+import sys
+import logging
 
+
+logging.basicConfig(level=logging.DEBUG)
 
 def create_app(test_config=None):
     # create and configure the app
     app = Flask(__name__, instance_relative_config=True)
+    # TODO: rewire all the print() statements to the app.logger
     app.config.from_object("vec_search.config")
-
+    app.logger.addHandler(logging.StreamHandler(sys.stdout))
+    app.logger.info("stdout stream handler added")
     if test_config is None:
         # load the instance config, if it exists, when not testing
         app.config.from_pyfile("config.py", silent=True)

--- a/vec_search/__init__.py
+++ b/vec_search/__init__.py
@@ -4,18 +4,21 @@ import sys
 import logging
 
 
-logging.basicConfig(level=logging.DEBUG)
+logging.basicConfig(level=logging.INFO)
 
 def create_app(test_config=None):
     # create and configure the app
     app = Flask(__name__, instance_relative_config=True)
     # TODO: rewire all the print() statements to the app.logger
     app.config.from_object("vec_search.config")
-    app.logger.addHandler(logging.StreamHandler(sys.stdout))
-    app.logger.info("stdout stream handler added")
     if test_config is None:
         # load the instance config, if it exists, when not testing
         app.config.from_pyfile("config.py", silent=True)
+        # the Handler class has a setLevel but Stream handler does not
+        h = logging.StreamHandler(sys.stdout)
+        h.setLevel(level=app.config.get('LOG_LEVEL'))
+        app.logger.addHandler(h)
+        app.logger.info("stderr stream handler added")
     else:
         # load the test config if passed in
         app.config.from_mapping(test_config)

--- a/vec_search/bedrock_batch.py
+++ b/vec_search/bedrock_batch.py
@@ -20,6 +20,24 @@ def gen_record_id(index: int, prefix: str = "REC") -> str:
     """Generate an 11 character alphanumeric record ID."""
     return f"{prefix}{str(index).zfill(8)}"
 
+def parse_resp(x: list[str]) -> int:
+    """
+
+    Args:
+        x (list[str]): A string with the llm response from the umbrella prompt.
+
+    Raises:
+        ValueError: if x is not a string.
+
+    Returns:
+        int: A binary 0/1 value for whether the model determined the relevance (1) or not (0)
+    """
+    try:
+        rel = max(0, min(int(x[1].strip()), 1))
+    except ValueError as e:
+        print(f"ValueError: {e}...")
+        rel = 0
+    return rel
 
 class ModelType(Enum):
     TITAN_TEXT_EXPRESS = "amazon.titan-text-express-v1"
@@ -226,5 +244,5 @@ def bb(df, prompt, output_filename):
         # construct parsed data
         p_df = DataFrame({'message': data})
         c_df = concat([df, p_df], axis=1)
-        c_df['llm_rel_score'] = c_df['message'].str.split(':').apply(lambda x: max(0, min(int(x[1].strip()), 1)))
+        c_df['llm_rel_score'] = c_df['message'].str.split(':').apply(parse_resp)
         c_df.to_csv(output_filename)

--- a/vec_search/config.py
+++ b/vec_search/config.py
@@ -11,6 +11,7 @@ import os
 
 DEBUG = True
 PREFERRED_URL_SCHEME = "http"
+LOG_LEVEL = "DEBUG" # this should always be set to smth
 SECRET_KEY = "dev"
 
 # NOTE: this assumes you always call from the repo root which is what

--- a/vec_search/db.py
+++ b/vec_search/db.py
@@ -1,15 +1,12 @@
 import csv
-import json
 import sqlean as sqlite3
 import sqlite_vec
-from collections import defaultdict
 from datetime import datetime
-from time import sleep
 
 import click
 import jsonlines
 from flask import current_app, g
-from pandas import read_csv, DataFrame, concat
+from pandas import read_csv, concat
 
 
 # HACK

--- a/vec_search/ir_eval_metrics.py
+++ b/vec_search/ir_eval_metrics.py
@@ -21,8 +21,8 @@ iv. Mean ave Precision@k
 
 from itertools import accumulate
 from math import isclose
-from typing import Union
 
+from flask import current_app as app
 from scipy.stats import spearmanr, kendalltau, geom
 from pandas import DataFrame, crosstab
 

--- a/vec_search/llm_rel_gen.py
+++ b/vec_search/llm_rel_gen.py
@@ -107,6 +107,8 @@ class LLMRelAssessor(LLMRelAssessorBase):
                         }
                     ],
                     model=self.model_name,
+                    temperature=0.4,
+                    max_tokens=512
                 )
                 resp = self.parse_resp(response) if parse else response
                 for key, value in resp.items():

--- a/vec_search/search.py
+++ b/vec_search/search.py
@@ -46,7 +46,6 @@ def index():
         q = request.args.get("q")
         if g.user is not None:
             # if user is logged in then record the query to query table
-            print(q, type(q), g.user["id"], "writing query to query table")
             SAVE_QUERY_CMD = "INSERT INTO queries(query, user_id) values (?, ?)"
             db.execute(SAVE_QUERY_CMD, [q, g.user["id"]])
             db.commit()
@@ -154,16 +153,12 @@ def detail():
 @bp.route("/relevance", methods=["GET"])
 def relevance():
     db = get_db()
-    print("in relevance route ...")
     post_id = int(request.args.get("post-id"))
     query_id = int(request.args.get("query-id"))
     rel = 1 if request.args.get("relevance") == "yes" else 0
     rank = int(request.args.get("rank"))
     dist = float(request.args.get("distance"))
     rel_record = [post_id, query_id, rel, rank, dist]
-    print("before relevance insert")
-    for row in db.execute("SELECT * FROM query_relevances").fetchall():
-        print(row.keys())
     # store the relevance data ...
     # NOTE: the relevance table has no constraint on (post_id, query_id)
     # being unique (to not break workflow of human relevance change yes->no or vice versa)
@@ -172,9 +167,6 @@ def relevance():
     SAVE_RELEVANCE_CMD = "INSERT INTO query_relevances(post_id, query_id, relevance, rank, distance) values (?, ?, ?, ?, ?)"
     db.execute(SAVE_RELEVANCE_CMD, rel_record)
     db.commit()
-    print("after relevance insert")
-    for row in db.execute("select * from query_relevances").fetchall():
-        print(row)
     # NOTE: we expect no returning content from this endpoint but we do
     # send back a simple status to ACK ...
     return {"status": "ok"}


### PR DESCRIPTION
Previously the llm was being loaded on each click command associated with the app because many of the commands are cli and downstream from the llm they don't need to load the llm. This pr achieves this at the cost of some cognitive load for adding new app commands which may use the llm from the config file. If in the future a new flask app command is added then we'll want to add a set to check.

 Also there are a couple exceptions on the
  parsing so I add a default 0 which is what
  is appearing in those cases anyway. 

For the exception handling we'll want that to be (eventually) moved out of `bedrock_batch` module and into `llm_gen_rel` because the function isn't specific 
to bedrock, that's just we're I've seen it so far. 

@D-Roberts when you've got a sec 