### PR TITLE
add bm25 baseline retriever

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ envvars.sh
 *.csv
 *.csv
 *.txt
+
+bedrock_batch_output*

--- a/README.md
+++ b/README.md
@@ -54,6 +54,39 @@ python3 -m venv .
 python3 -m pip install -r requirements.txt
 ```
 
+## configure the app
+
+The majority of the configuration on the flask app is done in the `vec_search/config.py` module.
+There are some common config items like `DEBUG` mode that we will omit here.
+
+The primary config items that impact the workflows are:
+| Config symbol name  | Tested values                  |
+|---------------------| -------------------------------|
+| AI_MODEL  | "Salesforce/codet5p-110m-embedding","microsoft/codebert-base-mlm"|
+| VEC_DIM | 256, 768 (first corresponds to Saleforce whilst second corresponds to codebert)  |
+| EMBED_ON_LOAD | True/False (setting to True embeds the entities inside the `init-db` click command) |
+| _JSONL_LOCAL_FILE | The path to the `.jsonl` file that contains the entities to be searched and annotated |
+| SEMANTIC | True/False Setting to use the chosen `AI_MODEL` retriever or the sparse `bm25` retriever respectively.
+
+
+Notes:
+
+(i) This will log a warning if the AI_MODEL and the embeddings in the db do not correspond 
+because of dimension size differences.
+We recommend the models be the same for indexing and for query embeddings.
+
+(ii) If a model besides the codeBERT model is used then the correct setting to use is `EMBED_ON_LOAD=True`.
+Here we assume you're using one of the projects in the git-lfs portion of the repo.
+Setting this config to `True` typically slows the time to initialize the database.
+If you've Indexed your own `.jsonl` files with an `'embeddings'` key-value pair for each entry
+then keep this set to `False` to use your own embeddings.
+
+(iii) The value of `VEC_DIM` is used to set the length of the vector store in the database.
+If you use a value that does not correspond to the length generated (`EMBED_ON_LOAD=True`)
+or previously calculated in the (`.jsonl` file) an error will be raised while executing the
+`init-db` click command indicating the size of the differences. The setup assumes all vectors
+are the same length when stored.
+
 ## initialize the db
 
 Update paths in vec_search/config.py file for DATABASE and for _SQLITE_VEC_DLL_PATH variables with your local paths.

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The primary config items that impact the workflows are:
 | VEC_DIM | 256, 768 (first corresponds to Saleforce whilst second corresponds to codebert)  |
 | EMBED_ON_LOAD | True/False (setting to True embeds the entities inside the `init-db` click command) |
 | _JSONL_LOCAL_FILE | The path to the `.jsonl` file that contains the entities to be searched and annotated |
-| SEMANTIC | True/False Setting to use the chosen `AI_MODEL` retriever or the sparse `bm25` retriever respectively.
+| SEMANTIC | True/False Setting to use the chosen `AI_MODEL` retriever or the sparse `bm25` retriever respectively |
 
 
 Notes:

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,7 @@ openai
 google-generativeai # NOTE: this one may be unnecessary, not sure though
 google-cloud-aiplatform
 huggingface_hub
+
+
+# additional retriever baselines
+bm25s>=0.2.10

--- a/vec_search/config.py
+++ b/vec_search/config.py
@@ -22,8 +22,8 @@ DATABASE = f"{os.getcwd()}/var/vec_search-instance/vec_search.sqlite"
 # these config values are for the model that is used to generate the embeddings
 # for now these need to work with `RobertaTokenizer` and `RobertaForMaskedLM`
 # via hf local cache but this will likely change
-AI_MODEL = "Salesforce/codet5p-110m-embedding" # VEC_DIM 256
-# AI_MODEL = "microsoft/codebert-base-mlm" # VEC_DIM 768
+# AI_MODEL = "Salesforce/codet5p-110m-embedding" # VEC_DIM 256
+AI_MODEL = "microsoft/codebert-base-mlm" # VEC_DIM 768
 
 DEVICE = "cpu"
 # the size of the vector embeddings-previously this was a literal in the schema.sql file
@@ -31,8 +31,8 @@ DEVICE = "cpu"
 # it so that you can configured the embeddings for different models. In other words, you
 # will want to set the value for `VEC_DIM` to the dimension of the vectors that are
 # returned by `AI_MODEL` chosen above
-VEC_DIM = 256 # for "Salesforce/codet5p-110m-embedding"
-#VEC_DIM = 768 # for "microsoft/codebert-base-mlm"
+# VEC_DIM = 256 # for "Salesforce/codet5p-110m-embedding"
+VEC_DIM = 768 # for "microsoft/codebert-base-mlm"
 
 # The initial workflow embedded the codebert-base-mlm model into the JSON.
 # If you have embeddings already in the JSONL file then keep this false.
@@ -40,7 +40,7 @@ VEC_DIM = 256 # for "Salesforce/codet5p-110m-embedding"
 # used in the jsonl file but used for the retriever, then setting this to
 # true will cause the system to feed the code functions through the `AI_MODEL`
 # it's handy for experimentations
-EMBED_ON_LOAD = True
+EMBED_ON_LOAD = False
 
 # this file contains the indexed contents of the code repo you have indexed
 # I do this via some custom forked code that is in a private repo
@@ -72,7 +72,7 @@ _SQLITE_VEC_DLL_PATH = (
 )
 
 # this config toggles the semantic retriever (true) vs a sparse retriever (false).
-# Currently, codebert is the supported retriever.
+# Codet5+ and CodeBERT are tested retrievers which have been tested end-2-end.
 SEMANTIC = True
 
 # this value reflects the number of results on the page

--- a/vec_search/config.py
+++ b/vec_search/config.py
@@ -52,3 +52,10 @@ _SQLITE_WORKSPACE = "sqlite-ext" if os.environ.get("USER") == "rlucas" else "ail
 _SQLITE_VEC_DLL_PATH = (
     f"/Users/{os.environ.get('USER')}/{_SQLITE_WORKSPACE}/sqlite-vec/dist/vec0.dylib"
 )
+
+# this config toggles the semantic retriever (true) vs a sparse retriever (false).
+# Currently, codebert is the supported retriever.
+SEMANTIC = False
+
+# this value reflects the number of results on the page
+N = 10

--- a/vec_search/config.py
+++ b/vec_search/config.py
@@ -22,7 +22,25 @@ DATABASE = f"{os.getcwd()}/var/vec_search-instance/vec_search.sqlite"
 # these config values are for the model that is used to generate the embeddings
 # for now these need to work with `RobertaTokenizer` and `RobertaForMaskedLM`
 # via hf local cache but this will likely change
-AI_MODEL = "microsoft/codebert-base-mlm"
+AI_MODEL = "Salesforce/codet5p-110m-embedding" # VEC_DIM 256
+# AI_MODEL = "microsoft/codebert-base-mlm" # VEC_DIM 768
+
+DEVICE = "cpu"
+# the size of the vector embeddings-previously this was a literal in the schema.sql file
+# but now we interpolate into that file using this value. The reason is that this makes
+# it so that you can configured the embeddings for different models. In other words, you
+# will want to set the value for `VEC_DIM` to the dimension of the vectors that are
+# returned by `AI_MODEL` chosen above
+VEC_DIM = 256 # for "Salesforce/codet5p-110m-embedding"
+#VEC_DIM = 768 # for "microsoft/codebert-base-mlm"
+
+# The initial workflow embedded the codebert-base-mlm model into the JSON.
+# If you have embeddings already in the JSONL file then keep this false.
+# If you want to generate embeddings for a model-perhaps not the model
+# used in the jsonl file but used for the retriever, then setting this to
+# true will cause the system to feed the code functions through the `AI_MODEL`
+# it's handy for experimentations
+EMBED_ON_LOAD = True
 
 # this file contains the indexed contents of the code repo you have indexed
 # I do this via some custom forked code that is in a private repo
@@ -55,7 +73,7 @@ _SQLITE_VEC_DLL_PATH = (
 
 # this config toggles the semantic retriever (true) vs a sparse retriever (false).
 # Currently, codebert is the supported retriever.
-SEMANTIC = False
+SEMANTIC = True
 
 # this value reflects the number of results on the page
 N = 10

--- a/vec_search/retriever.py
+++ b/vec_search/retriever.py
@@ -18,9 +18,8 @@ from vec_search.config import N, DEVICE
 from flask import current_app as app
 
 class Retriever:
-    def __init__(self, semantic:bool, db:Any, filepath: Optional[str]=None):
+    def __init__(self, semantic:bool, filepath: Optional[str]=None):
         self.is_semantic = semantic
-        self.db = db
         if self.is_semantic:
             if MODEL == "Salesforce/codet5p-110m-embedding":
                 self._MODEL = AutoModel.from_pretrained(MODEL, trust_remote_code=True).to(DEVICE)
@@ -39,7 +38,7 @@ class Retriever:
         if self.is_semantic:
             raise ValueError(f"setting a sparse retriever on a semantic model!")
         else:
-            app.logger.info(f"found is_semantic = {self.is_semantic}, initializing bm25 index and retriever...")
+            #app.logger.info(f"found is_semantic = {self.is_semantic}, initializing bm25 index and retriever...")
             with open(filepath, 'r') as jsonl_file:
                 result = [json.loads(jline) for jline in jsonl_file.readlines()]
             # following example from
@@ -53,6 +52,10 @@ class Retriever:
             corpus_tokens = bm25s.tokenize(corpus_text, stopwords="en")
             self.retriever = bm25s.BM25(corpus=corpus)
             self.retriever.index(corpus_tokens)
+
+    def _attach_db(self, db: Any) -> None:
+        """attaches the db to the retriever"""
+        self.db = db
 
     def retrieve(self, user: Any, query:str) -> list[dict[str, Any]]:
         """Retrieve specified number of results based on query and retriever type.

--- a/vec_search/retriever.py
+++ b/vec_search/retriever.py
@@ -72,6 +72,8 @@ class Retriever:
             self.db.commit()
             for row in self.db.execute("SELECT last_insert_rowid()").fetchall():
                 query_id = row["last_insert_rowid()"]
+        else:
+            query_id = "<none>"
         if self.is_semantic:
             if MODEL == "microsoft/codebert-base-mlm":
                 app.logger.info(f"Running semantic search using codebert on query...")

--- a/vec_search/retriever.py
+++ b/vec_search/retriever.py
@@ -1,0 +1,131 @@
+"""This module houses the retriever class.
+The retriever class encapsulates both semantic and sparse retrievers.
+Sparse retrievers leverage the bm25s package.
+"""
+from typing import Optional, Any
+
+import bm25s
+import json
+import sqlite_vec
+
+from torch import tensor, reshape, FloatTensor
+from transformers import RobertaTokenizer, RobertaForMaskedLM
+
+from vec_search.config import AI_MODEL as MODEL
+from vec_search.config import N
+
+from flask import current_app as app
+
+class Retriever:
+    def __init__(self, semantic:bool, db:Any, filepath: Optional[str]=None):
+        self.is_semantic = semantic
+        self.db = db
+        if self.is_semantic:
+            self._MODEL = RobertaForMaskedLM.from_pretrained(MODEL)
+            self._TOKENIZER = RobertaTokenizer.from_pretrained(MODEL)
+        else: # bm25 case is assumed
+
+            if filepath is not None:
+                self._set_bm25_retriever(filepath)
+
+    def _set_bm25_retriever(self, filepath:str) -> None:
+        """internal method"""
+        if self.is_semantic:
+            raise ValueError(f"setting a sparse retriever on a semantic model!")
+        else:
+            app.logger.info(f"found is_semantic = {self.is_semantic}, initializing bm25 index and retriever...")
+            with open(filepath, 'r') as jsonl_file:
+                result = [json.loads(jline) for jline in jsonl_file.readlines()]
+            # following example from
+            # https://github.com/xhluca/bm25s/blob/main/examples/index_with_metadata.py
+            # we index the source and associate the post.id as the `rowid`
+            # then we get the data from the selected top-k entries from `post` table
+            # via the `rowid`. The reason we do this is because we want to use the
+            # table to populate the SERP
+            corpus = [{"text": result[i].get('original_string'), "rowid": str(i)} for i in range(len(result))]
+            corpus_text = [doc["text"] for doc in corpus]
+            corpus_tokens = bm25s.tokenize(corpus_text, stopwords="en")
+            self.retriever = bm25s.BM25(corpus=corpus)
+            self.retriever.index(corpus_tokens)
+
+    def retrieve(self, user: Any, query:str) -> list[dict[str, Any]]:
+        """Retrieve specified number of results based on query and retriever type.
+
+        Args:
+            user (Any): A user from the global flask object if the user is logged in, or None if not.
+            query (str): A string containing the query.
+        """
+        if user is not None:
+            app.logger.info(f"A `user` value was included with query, storing in `queries` table...")
+            # if user is logged in then record the query to query table regardless of semantic or not
+            SAVE_QUERY_CMD = "INSERT INTO queries(query, user_id) values (?, ?)"
+            self.db.execute(SAVE_QUERY_CMD, [query, user["id"]])
+            self.db.commit()
+            for row in self.db.execute("SELECT last_insert_rowid()").fetchall():
+                query_id = row["last_insert_rowid()"]
+        if self.is_semantic:
+            app.logger.info(f"Running semantic search on query...")
+            # embed natural language query into embedding vector
+            tokens = (
+                [self._TOKENIZER.cls_token] + self._TOKENIZER.tokenize(query) + [self._TOKENIZER.eos_token]
+            )
+            raw_token_ids = tensor(self._TOKENIZER.convert_tokens_to_ids(tokens))
+            tokens_ids = reshape(raw_token_ids, (1, len(raw_token_ids)))
+            context_embeddings = self._MODEL(tokens_ids, output_hidden_states=True)
+            embeds = context_embeddings.hidden_states[-1].detach().numpy()[0, 0, :]
+            embed = embeds.tolist()
+            # now retrieve the top k entries
+            cur = self.db.cursor()
+            vec_query = f"""
+                with knn_matches as (
+                  select
+                    rowid,
+                    distance
+                  from vec_items
+                  where embedding match ?
+                    and k = {N}
+                )
+                select
+                  func_name,
+                  path,
+                  sha,
+                  code,
+                  doc,
+                  knn_matches.distance as distance,
+                  post.id as postid
+                from knn_matches
+                left join post on post.id = knn_matches.rowid
+            """
+            # grab the query id to keep the ids client unique
+            for row in self.db.execute("SELECT last_insert_rowid()").fetchall():
+                query_id = row["last_insert_rowid()"]
+            cur.execute(vec_query, [sqlite_vec.serialize_float32(embed)])
+            posts = cur.fetchall()
+            # now convert all posts into what we want for the client, a bunch of dicts
+            for i in range(len(posts)):
+                posts[i].update({"search-query": query})
+                posts[i].update({"query-id": str(query_id) + f"+post-num-{i}", "rank": str(i)})
+            cur.close()
+            return posts
+        else:
+            app.logger.info(f"Running sparse (bm25) search on query...")
+            # this is a BM25/sparse retriever
+            results, scores = self.retriever.retrieve(bm25s.tokenize(query), k=N)
+            # format `doc`s and `score`s to match `posts` from semantic side...
+            rows_ids = ','.join([results[0, i].get("rowid") for i in range(N)])
+            post_query = f"""SELECT func_name, path, sha, code, doc, post.id as postid FROM post WHERE id IN ({rows_ids})"""
+            cur = self.db.cursor()
+            cur.execute(post_query)
+            posts = cur.fetchall()
+            posts.sort(key = lambda x: x.get('postid'))
+            rowid_scores = [(int(results[0, i]['rowid']), scores[0, i]) for i in range(N)]
+            rowid_scores.sort()
+            for i in range(len(posts)):
+                posts[i].update({"search-query": query})
+                # dividing by 1000 here (mostly removes the effect in the template intended for cosine distance
+                posts[i].update({"distance": rowid_scores[i][1]/1000})
+            # now rank accoring to score/distance, with bm25 higher is better, whereas for cosine (in semantic True) lower is better
+            posts.sort(key=lambda x: -x['distance'])
+            for i in range(len(posts)):
+                posts[i].update({"query-id": str(query_id) + f"+post-num-{i}", "rank": str(i)})
+            return posts

--- a/vec_search/search.py
+++ b/vec_search/search.py
@@ -1,6 +1,5 @@
 import sys
 
-import sqlite_vec
 from flask import Blueprint, flash, g, redirect, render_template, request, url_for
 from torch import tensor, reshape, FloatTensor
 from werkzeug.exceptions import abort
@@ -12,9 +11,10 @@ from markupsafe import Markup
 
 from vec_search.auth import login_required
 from vec_search.db import get_db
-
+from vec_search.retriever import Retriever
 # HACK: for now hard codes the location of the config file for AI MODEL
 from vec_search.config import AI_MODEL as MODEL
+from vec_search.config import SEMANTIC, _JSONL_LOCAL_FILE, N
 
 bp = Blueprint("search", __name__)
 
@@ -38,60 +38,13 @@ def index():
     if request.method == "GET" and request.args.get("q") is None:
         # TODO: setup pagination
         posts = db.execute(
-            "SELECT func_name, path, sha, code, doc FROM post limit 10"
+            f"SELECT func_name, path, sha, code, doc FROM post limit {N}"
         ).fetchall()
         return render_template("search/index.html", posts=posts)
     elif request.method == "GET" and request.args.get("q") is not None:
-        # load the LLM to embed the natural lang text to a vec
-        q = request.args.get("q")
-        if g.user is not None:
-            # if user is logged in then record the query to query table
-            SAVE_QUERY_CMD = "INSERT INTO queries(query, user_id) values (?, ?)"
-            db.execute(SAVE_QUERY_CMD, [q, g.user["id"]])
-            db.commit()
-        # block of code to embed natural language query
-        tokens = (
-            [_TOKENIZER.cls_token] + _TOKENIZER.tokenize(q) + [_TOKENIZER.eos_token]
-        )
-        raw_token_ids = tensor(_TOKENIZER.convert_tokens_to_ids(tokens))
-        tokens_ids = reshape(raw_token_ids, (1, len(raw_token_ids)))
-        context_embeddings = _MODEL(tokens_ids, output_hidden_states=True)
-        embeds = context_embeddings.hidden_states[-1].detach().numpy()[0, 0, :]
-        embed = embeds.tolist()
-        # find matches
-        cur = db.cursor()
-        vec_query = """
-            with knn_matches as (
-              select
-                rowid,
-                distance
-              from vec_items
-              where embedding match ?
-                and k = 10
-            )
-            select
-              func_name,
-              path,
-              sha,
-              code,
-              doc,
-              knn_matches.distance as distance,
-              post.id as postid
-            from knn_matches
-            left join post on post.id = knn_matches.rowid
-        """
-        # grab the query id to keep the ids client unique
-        for row in db.execute("SELECT last_insert_rowid()").fetchall():
-            query_id = row["last_insert_rowid()"]
-        cur.execute(vec_query, [sqlite_vec.serialize_float32(embed)])
-        posts = cur.fetchall()
-        for i in range(len(posts)):
-            posts[i].update({"search-query": q})
-            if g.user and q:
-                posts[i].update(
-                    {"query-id": str(query_id) + f"+post-num-{i}", "rank": str(i)}
-                )
-        cur.close()
+        # ADDING bm25 SUPPORT HERE
+        retriever = Retriever(semantic=SEMANTIC, db=db, filepath=None if SEMANTIC else _JSONL_LOCAL_FILE)
+        posts = retriever.retrieve(user = g.user, query=request.args.get("q"))
         return render_template("search/index.html", posts=posts)
     else:
         raise ValueError("should not ever enter this branch")

--- a/vec_search/search.py
+++ b/vec_search/search.py
@@ -14,7 +14,7 @@ from vec_search.db import get_db
 from vec_search.retriever import Retriever
 # HACK: for now hard codes the location of the config file for AI MODEL
 from vec_search.config import AI_MODEL as MODEL
-from vec_search.config import SEMANTIC, _JSONL_LOCAL_FILE, N
+from vec_search.config import SEMANTIC, _JSONL_LOCAL_FILE, N, DEVICE
 
 bp = Blueprint("search", __name__)
 
@@ -25,10 +25,14 @@ if str(sys.argv[3]) == "run":
     # in this case-and only this case for now-we import the HF LLM
     # the basic purpose here is to not do a reload for every invocation
     # of a cli cmd
-    from transformers import RobertaTokenizer, RobertaForMaskedLM
-    from vec_search.config import AI_MODEL as MODEL
-    _MODEL = RobertaForMaskedLM.from_pretrained(MODEL)
-    _TOKENIZER = RobertaTokenizer.from_pretrained(MODEL)
+    if MODEL == "microsoft/codebert-base-mlm":
+        from transformers import RobertaTokenizer, RobertaForMaskedLM
+        _MODEL = RobertaForMaskedLM.from_pretrained(MODEL)
+        _TOKENIZER = RobertaTokenizer.from_pretrained(MODEL)
+    elif MODEL == "Salesforce/codet5p-110m-embedding":
+        from transformers import AutoModel, AutoTokenizer
+        _MODEL = AutoModel.from_pretrained(MODEL, trust_remote_code=True).to(DEVICE)
+        _TOKENIZER = AutoTokenizer.from_pretrained(MODEL, trust_remote_code=True)
 
 
 # we hack the GET & disambiguate a search


### PR DESCRIPTION
  * This commit adds:
    - ignores the bedrock output files
    - make k in top-k & sparse vs semantic search styles configurable
    - adds a Retriever class that obfuscates the search type interfaces
 

I've tested the workflow in a localhost browser and things seem to be working as expected.
