### PR TITLE
store queries if user is not authenticated

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ INNER JOIN (
 GROUP BY
 q.query_id,
 user_id,
+
 post_id
 ;
 

--- a/vec_search/db.py
+++ b/vec_search/db.py
@@ -137,7 +137,14 @@ def reset_users():
     click.echo(
         "WARNING: the user table has been reset, all user_id associations in the queries table are lost ..."
     )
-
+    db.execute(
+        "INSERT INTO user (username, password) VALUES (?, ?)",
+            (-1, "anonymous"),
+    )
+    db.commit()
+    click.echo(
+        "INFO: the user table has the anonymous user added, all non-authenticated user_id associations in the queries table are associated to this user"
+    )
 
 @click.command("init-db")
 def init_db_command():

--- a/vec_search/search.py
+++ b/vec_search/search.py
@@ -51,6 +51,8 @@ def index():
         return render_template("search/index.html", posts=posts)
     elif request.method == "GET" and request.args.get("q") is not None:
         retriever._attach_db(db=db)
+        if g.user is None:
+            flash("Your queries will not be saved with your relevance annotations until you authenticate.")
         posts = retriever.retrieve(user = g.user, query=request.args.get("q"))
         return render_template("search/index.html", posts=posts)
     else:

--- a/vec_search/templates/base.html
+++ b/vec_search/templates/base.html
@@ -1,4 +1,28 @@
 <!doctype html>
+<style>
+  .animated {
+     background-position: left top;
+     padding-top:95px;
+     margin-bottom:60px;
+     -webkit-animation-duration: 10s;animation-duration: 10s;
+     -webkit-animation-fill-mode: both;animation-fill-mode: both;
+  }
+
+  @-webkit-keyframes fadeOut {
+     0% {opacity: 1;}
+     100% {opacity: 0;}
+  }
+
+  @keyframes fadeOut {
+     0% {opacity: 1;}
+     100% {opacity: 0;}
+  }
+
+  .fadeOut {
+     -webkit-animation-name: fadeOut;
+     animation-name: fadeOut;
+  }
+</style>
 <title>{% block title %}{% endblock %} - VecSearch</title>
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
 <link rel="shortcut icon" href="{{ url_for('static', filename='favicon.ico') }}">
@@ -10,7 +34,7 @@
       <li><span>{{ g.user['username'] }}</span>
       <li><a href="{{ url_for('auth.logout') }}">Log Out</a>
     {% else %}
-    <span id="login-tt" class="tt" data-bs-placement="bottom" data-toggle="login-tooltip" title="Relevance workflow requires you to log in (register to create a user)">
+    <span id="login-tt" class="tt" data-bs-placement="bottom" data-toggle="login-tooltip" title="Relevance workflow expects you to log in (register to create a user)">
       <span class="login"></span>
       <li><a href="{{ url_for('auth.register') }}">Register</a>
       <li><a href="{{ url_for('auth.login') }}">Log In</a>
@@ -23,7 +47,9 @@
     {% block header %}{% endblock %}
   </header>
   {% for message in get_flashed_messages() %}
-    <div class="flash">{{ message }}</div>
+    <div class="flash animated fadeOut">
+      {{ message }}
+    </div>
   {% endfor %}
   {% block content %}{% endblock %}
 </section>


### PR DESCRIPTION
Previously neither queries nor relevances were stored if the user was not authenticated. With the addition of more retrievers I removed the authentication gating. This caused an issue where relevances were stored but the queries were not stored in the db. Causing RAD output to be empty which surprises the user. This change makes it so that the users queries and relevance determinations are both stored in the db regardless of authentication status. The queries are stored under the `-1/anonymous` user if the user is not authenticated when executing queries and marking relevances.

This seems to work for me locally on codebert. I want to test this a bit more thoroughly with this and the other 2 retrievers
and also add some sort of alerting to the user before merging so I'm leaving this in draft status. Also, this change is non-blocking. The current workflow (on the tip of main) ***expects*** the user to be authenticated when marking relevant results in the searches. This PR is intended to ease that requirement. 

The alerting should be some gentle nudging, not something that prevents the workflow altogether.

Marking as draft until I can do more thorough testing and add some gentle alert to the human. 