### PR TITLE
increase aws iteration limit

### DIFF
--- a/vec_search/bedrock_batch.py
+++ b/vec_search/bedrock_batch.py
@@ -215,7 +215,7 @@ def bb(df, prompt, output_filename):
     )
     app.logger.info(response)
     jobArn = response.get('jobArn')
-    poll_cnt, max_poll_cnt = 1, 20
+    poll_cnt, max_poll_cnt = 1, 60
 
     while poll_cnt < max_poll_cnt:
         sleep(30)


### PR DESCRIPTION
  * previously 20, 30 second pauses was more than enough but now it needs to be a bit larger to prevent timeout

Ran into this when trying to rerun the c-lang code. Three-fold increase to the max iteration count for polling seems adequate now. 